### PR TITLE
Expose OC dataprovider http port in services

### DIFF
--- a/revad/Chart.yaml
+++ b/revad/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: revad
 description: The Reva daemon (revad) helm chart
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: v0.1.0
 icon: https://reva.link/logo.svg
 home: https://reva.link

--- a/revad/templates/deployment.yaml
+++ b/revad/templates/deployment.yaml
@@ -20,10 +20,13 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 20080
+              containerPort: {{ .Values.service.http.port }}
               protocol: TCP
             - name: grpc
-              containerPort: 20099
+              containerPort: {{ .Values.service.grpc.port }}
+              protocol: TCP
+            - name: dataprovider
+              containerPort: {{ .Values.service.dataprovider.port }}
               protocol: TCP
           command:
             - /go/bin/revad

--- a/revad/templates/service.yaml
+++ b/revad/templates/service.yaml
@@ -15,6 +15,10 @@ spec:
       targetPort: grpc
       protocol: TCP
       name: grpc
+    - port: {{ .Values.service.dataprovider.port }}
+      targetPort: dataprovider
+      protocol: TCP
+      name: dataprovider
     {{- if .Values.service.gateway }}
     - port: {{ .Values.service.gateway.grpc.port }}
       targetPort: gateway

--- a/revad/values.yaml
+++ b/revad/values.yaml
@@ -11,6 +11,8 @@ service:
     port: 20080
   grpc:
     port: 20099
+  dataprovider:
+    port: 11001
   gateway:
     grpc:
       port: 19000
@@ -45,7 +47,33 @@ configFiles:
     address = "0.0.0.0:19001"
 
     [http.services.datagateway]
+  storage-oc.toml: |
+    [shared]
+    jwt_secret = "mysecret"
+    gatewaysvc = "localhost:19000"
 
+    [grpc]
+    address = "0.0.0.0:11000"
+
+    [grpc.services.storageprovider]
+    driver = "owncloud"
+    mount_path = "/oc"
+    mount_id = "a71054f7-947f-4709-9992-2ad62fe24fa4"
+    expose_data_server = true
+    data_server_url = "http://localhost:11001/data"
+
+    [grpc.services.storageprovider.drivers.owncloud]
+    datadirectory = "/var/tmp/reva/data"
+
+    [http]
+    address = "0.0.0.0:11001"
+
+    [http.services.dataprovider]
+    driver = "owncloud"
+    temp_folder = "/var/tmp/reva/tmp"
+
+    [http.services.dataprovider.drivers.owncloud]
+    datadirectory = "/var/tmp/reva/data"
 
 args: []
 workingDir: ""


### PR DESCRIPTION
Expose OC dataprovider HTTP endpoint (`11001` by default) in chart services. This port is required to be accessible externally for direct uploads from clients (e. g. Phoenix) to work.