### PR TITLE
Create a separate ConfigMap for each revad container

### DIFF
--- a/revad/Chart.yaml
+++ b/revad/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: revad
 description: The Reva daemon (revad) helm chart
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: v0.1.0
 icon: https://reva.link/logo.svg
 home: https://reva.link

--- a/revad/templates/deployment.yaml
+++ b/revad/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
           workingDir: {{ .Values.workingDir }}
           {{- end }}
           volumeMounts:
-            - name: {{ include "revad.fullname" . }}-configfiles
+            - name: {{ include "revad.fullname" . }}-revad-configfiles
               mountPath: /etc/revad/
         {{- if .Values.service.gateway }}
         - name: {{ .Chart.Name }}-gateway
@@ -64,10 +64,14 @@ spec:
               - "-p"
               - "/var/run/revad.pid"
           volumeMounts:
-            - name: {{ include "revad.fullname" . }}-configfiles
+            - name: {{ include "revad.fullname" . }}-gateway-configfiles
               mountPath: /etc/revad/
           {{- end }}
       volumes:
-        - name: {{ include "revad.fullname" . }}-configfiles
+        {{- range $configMapName, $_ := .Values.configFiles }}
+        - name: "{{ include "revad.fullname" $ }}-{{ $configMapName }}-configfiles"
           configMap:
-            name: {{ template "revad.fullname" . }}-config
+            name: "{{ template "revad.fullname" $ }}-{{ $configMapName }}-config"
+        {{- end }}
+
+

--- a/revad/templates/revad-config.yaml
+++ b/revad/templates/revad-config.yaml
@@ -1,13 +1,14 @@
-{{- if .Values.configFiles }}
+{{- range $configMapName, $configMap := .Values.configFiles }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "revad.fullname" . }}-config
+  name: {{ include "revad.fullname" $ }}-{{ $configMapName }}-config
   labels:
-    {{- include "revad.labels" . | nindent 4 }}
+    {{- include "revad.labels" $ | nindent 4 }}
 data:
-{{- range $filename, $fileContents := .Values.configFiles }}
+{{- range $filename, $fileContents := $configMap }}
   {{ $filename }}: |-
 {{ $fileContents | indent 4 }}
 {{- end }}
+---
 {{- end }}

--- a/revad/values.yaml
+++ b/revad/values.yaml
@@ -21,59 +21,62 @@ service:
 
 # https://reva.link/docs/config/
 configFiles:
-  revad.toml: |
-    [shared]
-    jwt_secret = "mysecret"
+  revad:
+    revad.toml: |
+      [shared]
+      jwt_secret = "mysecret"
 
-    [http]
-    address = "0.0.0.0:20080"
+      [http]
+      address = "0.0.0.0:20080"
 
-    [http.services.prometheus]
+      [http.services.prometheus]
 
-    [grpc]
-    address = "0.0.0.0:20099"
-  gateway.toml: |
-    [shared]
-    jwt_secret = "mysecret"
-    gatewaysvc = "localhost:19000"
+      [grpc]
+      address = "0.0.0.0:20099"
 
-    [grpc]
-    address = "0.0.0.0:19000"
+    storage-oc.toml: |
+      [shared]
+      jwt_secret = "mysecret"
+      gatewaysvc = "localhost:19000"
 
-    [grpc.services.gateway]
-    datagateway = "http://localhost:19001/data"
+      [grpc]
+      address = "0.0.0.0:11000"
 
-    [http]
-    address = "0.0.0.0:19001"
+      [grpc.services.storageprovider]
+      driver = "owncloud"
+      mount_path = "/oc"
+      mount_id = "a71054f7-947f-4709-9992-2ad62fe24fa4"
+      expose_data_server = true
+      data_server_url = "http://localhost:11001/data"
 
-    [http.services.datagateway]
-  storage-oc.toml: |
-    [shared]
-    jwt_secret = "mysecret"
-    gatewaysvc = "localhost:19000"
+      [grpc.services.storageprovider.drivers.owncloud]
+      datadirectory = "/var/tmp/reva/data"
 
-    [grpc]
-    address = "0.0.0.0:11000"
+      [http]
+      address = "0.0.0.0:11001"
 
-    [grpc.services.storageprovider]
-    driver = "owncloud"
-    mount_path = "/oc"
-    mount_id = "a71054f7-947f-4709-9992-2ad62fe24fa4"
-    expose_data_server = true
-    data_server_url = "http://localhost:11001/data"
+      [http.services.dataprovider]
+      driver = "owncloud"
+      temp_folder = "/var/tmp/reva/tmp"
 
-    [grpc.services.storageprovider.drivers.owncloud]
-    datadirectory = "/var/tmp/reva/data"
+      [http.services.dataprovider.drivers.owncloud]
+      datadirectory = "/var/tmp/reva/data"
+  gateway:
+    gateway.toml: |
+      [shared]
+      jwt_secret = "mysecret"
+      gatewaysvc = "localhost:19000"
 
-    [http]
-    address = "0.0.0.0:11001"
+      [grpc]
+      address = "0.0.0.0:19000"
 
-    [http.services.dataprovider]
-    driver = "owncloud"
-    temp_folder = "/var/tmp/reva/tmp"
+      [grpc.services.gateway]
+      datagateway = "http://localhost:19001/data"
 
-    [http.services.dataprovider.drivers.owncloud]
-    datadirectory = "/var/tmp/reva/data"
+      [http]
+      address = "0.0.0.0:19001"
+
+      [http.services.datagateway]
 
 args: []
 workingDir: ""


### PR DESCRIPTION
This will also allow in the future to ditch running the main 'revad' container with -dev-dir by mounting their config (.toml, .json, ...) on the right container. 

**IMPORTANT:** Breaking changes in `values.yaml` - notice the nesting: 

```yaml
configFiles:
  revad:
    revad.toml: |
      ... 
  gateway:
    gateway.toml: |
      ...
```
Update yours accordingly:

```console
$ helm get values revad > revad.yaml
$ helm upgrade revad cs3org/revad -f revad.yaml
```

### Comparison:

#### Before:

```console
$ kubectl exec -ti revad-78dd4c9c45-xd62m -c revad -- ls /etc/revad
gateway.toml  revad.toml
$ kubectl exec -ti revad-78dd4c9c45-xd62m -c revad-gateway -- ls /etc/revad
gateway.toml  revad.toml
```

#### Now:

```console
$ kubectl exec -ti revad-685775b67c-776tj -c revad -- ls /etc/revad
revad.toml
$ kubectl exec -ti revad-685775b67c-776tj -c revad-gateway -- ls /etc/revad
gateway.toml
```

Fixes https://github.com/cs3org/charts/issues/3 - cc/ @mirekys

### Contributing a Chart / update to an existing Chart

- [x] Run `helm lint` on the chart dir.
- [x] (Update) Bump the `Chart.yaml` version before merging, to release it as a new version. 
> (bump to `0.1.4` after we merge and rebase #4)
