### PR TITLE
Standalone revad Chart refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,53 @@ $ helm search repo cs3org
 NAME        	CHART VERSION	APP VERSION	DESCRIPTION
 cs3org/revad	0.1.0        	0.1.0      	The Reva daemon (revad) helm chart
 ```
+
+## Examples
+
+### Running REVAD as dataprovider
+
+```console
+$ cat << EOF > storage-oc.yaml
+service:
+  grpc:
+    port: 11000
+  http:
+    port: 11001
+configFiles:
+  revad.toml: |
+    [grpc]
+    address = "0.0.0.0:11000"
+
+    [grpc.services.storageprovider]
+    driver = "owncloud"
+    mount_path = "/oc"
+    mount_id = "a71054f7-947f-4709-9992-2ad62fe24fa4"
+    expose_data_server = true
+    data_server_url = "http://localhost:11001/data"
+
+    [grpc.services.storageprovider.drivers.owncloud]
+    datadirectory = "/var/tmp/reva/data"
+
+    [http]
+    address = "0.0.0.0:11001"
+
+    [http.services.dataprovider]
+    driver = "owncloud"
+    temp_folder = "/var/tmp/reva/tmp"
+
+    [http.services.dataprovider.drivers.owncloud]
+    datadirectory = "/var/tmp/reva/data"
+EOF
+
+$ helm install dataprovider cs3org/revad -f storage-oc.yaml
+```
+or
+
+```console
+$ helm install dataprovider cs3org/revad \
+  --set service.grpc.port=11000 \
+  --set service.http.port=11001 \
+  --set-file configFiles.revad.toml=storage-oc.toml
+```
+
+Thanks to @mirekys for the contribution!

--- a/README.md
+++ b/README.md
@@ -24,55 +24,32 @@ cs3org	https://cs3org.github.io/charts/
 
 $ helm search repo cs3org
 NAME        	CHART VERSION	APP VERSION	DESCRIPTION
-cs3org/revad	0.1.0        	0.1.0      	The Reva daemon (revad) helm chart
+cs3org/revad	0.1.4        	0.1.0      	The Reva daemon (revad) helm chart
 ```
 
 ## Examples
 
-### Running REVAD as dataprovider
+### Deploying REVA with custom config
 
 ```console
-$ cat << EOF > storage-oc.yaml
+$ cat << EOF > custom-values.yaml
 service:
-  grpc:
-    port: 11000
   http:
-    port: 11001
+    port: 20001
 configFiles:
   revad.toml: |
-    [grpc]
-    address = "0.0.0.0:11000"
-
-    [grpc.services.storageprovider]
-    driver = "owncloud"
-    mount_path = "/oc"
-    mount_id = "a71054f7-947f-4709-9992-2ad62fe24fa4"
-    expose_data_server = true
-    data_server_url = "http://localhost:11001/data"
-
-    [grpc.services.storageprovider.drivers.owncloud]
-    datadirectory = "/var/tmp/reva/data"
-
     [http]
-    address = "0.0.0.0:11001"
+    address = "0.0.0.0:20001"
 
-    [http.services.dataprovider]
-    driver = "owncloud"
-    temp_folder = "/var/tmp/reva/tmp"
-
-    [http.services.dataprovider.drivers.owncloud]
-    datadirectory = "/var/tmp/reva/data"
+    [http.services.helloworld]
 EOF
 
-$ helm install dataprovider cs3org/revad -f storage-oc.yaml
+$ helm install custom-reva cs3org/revad -f custom-values.yaml
 ```
 or
 
 ```console
-$ helm install dataprovider cs3org/revad \
-  --set service.grpc.port=11000 \
-  --set service.http.port=11001 \
-  --set-file configFiles.revad.toml=storage-oc.toml
+$ helm install custom-reva cs3org/revad \
+  --set service.http.port=20001 \
+  --set-file configFiles.revad\.toml=custom-config.toml
 ```
-
-Thanks to @mirekys for the contribution!

--- a/revad/Chart.yaml
+++ b/revad/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: revad
 description: The Reva daemon (revad) helm chart
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: v0.1.0
 icon: https://reva.link/logo.svg
 home: https://reva.link

--- a/revad/templates/deployment.yaml
+++ b/revad/templates/deployment.yaml
@@ -25,48 +25,16 @@ spec:
             - name: grpc
               containerPort: {{ .Values.service.grpc.port }}
               protocol: TCP
-            - name: dataprovider
-              containerPort: {{ .Values.service.dataprovider.port }}
-              protocol: TCP
           command:
             - /go/bin/revad
           args:
-            {{- if .Values.args }}
-{{ toYaml .Values.args | indent 14 }}
-            {{- else }}
               - "-c"
               - "/etc/revad/revad.toml"
               - "-p"
               - "/var/run/revad.pid"
-            {{- end }}
-          {{- if .Values.workingDir }}
-          workingDir: {{ .Values.workingDir }}
-          {{- end }}
           volumeMounts:
             - name: {{ include "revad.fullname" . }}-configfiles
               mountPath: /etc/revad/
-        {{- if .Values.service.gateway }}
-        - name: {{ .Chart.Name }}-gateway
-          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          ports:
-            - name: gateway
-              containerPort: 19000
-              protocol: TCP
-            - name: datagateway
-              containerPort: 19001
-              protocol: TCP
-          command:
-            - /go/bin/revad
-          args:
-              - "-c"
-              - "/etc/revad/gateway.toml"
-              - "-p"
-              - "/var/run/revad.pid"
-          volumeMounts:
-            - name: {{ include "revad.fullname" . }}-configfiles
-              mountPath: /etc/revad/
-          {{- end }}
       volumes:
         - name: {{ include "revad.fullname" . }}-configfiles
           configMap:

--- a/revad/templates/deployment.yaml
+++ b/revad/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
             - name: {{ include "revad.fullname" . }}-configfiles
               mountPath: /etc/revad/
             - name: {{ include "revad.fullname" . }}-datadir
-              mountPath: /var/tmp/reva/data
+              mountPath: /var/tmp/reva/
       volumes:
         - name: {{ include "revad.fullname" . }}-configfiles
           configMap:

--- a/revad/templates/deployment.yaml
+++ b/revad/templates/deployment.yaml
@@ -35,7 +35,12 @@ spec:
           volumeMounts:
             - name: {{ include "revad.fullname" . }}-configfiles
               mountPath: /etc/revad/
+            - name: {{ include "revad.fullname" . }}-datadir
+              mountPath: /var/tmp/reva/data
       volumes:
         - name: {{ include "revad.fullname" . }}-configfiles
           configMap:
             name: {{ template "revad.fullname" . }}-config
+        # TODO(SamuAlfageme): allow PersistentVolmeClaim custom Value
+        - name: {{ include "revad.fullname" . }}-datadir
+          emptyDir: {}

--- a/revad/templates/service.yaml
+++ b/revad/templates/service.yaml
@@ -15,19 +15,5 @@ spec:
       targetPort: grpc
       protocol: TCP
       name: grpc
-    - port: {{ .Values.service.dataprovider.port }}
-      targetPort: dataprovider
-      protocol: TCP
-      name: dataprovider
-    {{- if .Values.service.gateway }}
-    - port: {{ .Values.service.gateway.grpc.port }}
-      targetPort: gateway
-      protocol: TCP
-      name: gateway
-    - port: {{ .Values.service.gateway.datagateway.port }}
-      targetPort: datagateway
-      protocol: TCP
-      name: datagateway
-    {{- end }}
   selector:
     {{- include "revad.selectorLabels" . | nindent 4 }}

--- a/revad/values.yaml
+++ b/revad/values.yaml
@@ -27,4 +27,39 @@ configFiles:
     [http.services.dataprovider]
     [http.services.prometheus]
 
-
+  users.json: |
+    [
+      {
+        "id": {
+          "opaque_id": "4c510ada-c86b-4815-8820-42cdf82c3d51",
+          "idp": "http://localhost:20080"
+        },
+        "username": "einstein",
+        "secret": "relativity",
+        "mail": "einstein@example.org",
+        "display_name": "Albert Einstein",
+        "groups": ["sailing-lovers", "violin-haters", "physics-lovers"]
+      },
+      {
+        "id": {
+          "opaque_id": "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c",
+          "idp": "http://localhost:20080"
+        },
+        "username": "marie",
+        "secret": "radioactivity",
+        "mail": "marie@example.org",
+        "display_name": "Marie Curie",
+        "groups": ["radium-lovers", "polonium-lovers", "physics-lovers"]
+      },
+      {
+        "id": {
+          "opaque_id": "932b4540-8d16-481e-8ef4-588e4b6b151c",
+          "idp": "http://localhost:20080"
+        },
+        "username": "richard",
+        "secret": "superfluidity",
+        "mail": "richard@example.org",
+        "display_name": "Richard Feynman",
+        "groups": ["quantum-lovers", "philosophy-haters", "physics-lovers"]
+      }
+    ]

--- a/revad/values.yaml
+++ b/revad/values.yaml
@@ -2,78 +2,29 @@ replicaCount: 1
 
 image:
   repository: cs3org/revad
-  tag: v0.1.0
-  pullPolicy: IfNotPresent
+  tag: latest
+  pullPolicy: Always
 
 service:
   type: ClusterIP
-  http:
-    port: 20080
   grpc:
-    port: 20099
-  dataprovider:
-    port: 11001
-  gateway:
-    grpc:
-      port: 19000
-    datagateway:
-      port: 19001
+    port: 19000
+  http:
+    port: 19001
 
 # https://reva.link/docs/config/
 configFiles:
   revad.toml: |
-    [shared]
-    jwt_secret = "mysecret"
-
-    [http]
-    address = "0.0.0.0:20080"
-
-    [http.services.prometheus]
-
-    [grpc]
-    address = "0.0.0.0:20099"
-  gateway.toml: |
-    [shared]
-    jwt_secret = "mysecret"
-    gatewaysvc = "localhost:19000"
-
-    [grpc]
-    address = "0.0.0.0:19000"
-
     [grpc.services.gateway]
-    datagateway = "http://localhost:19001/data"
-
-    [http]
-    address = "0.0.0.0:19001"
-
-    [http.services.datagateway]
-  storage-oc.toml: |
-    [shared]
-    jwt_secret = "mysecret"
-    gatewaysvc = "localhost:19000"
-
-    [grpc]
-    address = "0.0.0.0:11000"
-
+    [grpc.services.storageregistry]
     [grpc.services.storageprovider]
-    driver = "owncloud"
-    mount_path = "/oc"
-    mount_id = "a71054f7-947f-4709-9992-2ad62fe24fa4"
-    expose_data_server = true
-    data_server_url = "http://localhost:11001/data"
-
-    [grpc.services.storageprovider.drivers.owncloud]
-    datadirectory = "/var/tmp/reva/data"
-
-    [http]
-    address = "0.0.0.0:11001"
+    [grpc.services.authprovider]
+    [grpc.services.authregistry]
+    [grpc.services.userprovider]
+    [grpc.services.usershareprovider]
+    [grpc.services.publicshareprovider]
 
     [http.services.dataprovider]
-    driver = "owncloud"
-    temp_folder = "/var/tmp/reva/tmp"
+    [http.services.prometheus]
 
-    [http.services.dataprovider.drivers.owncloud]
-    datadirectory = "/var/tmp/reva/data"
 
-args: []
-workingDir: ""


### PR DESCRIPTION
This is a followup of the changes in:
- https://github.com/cs3org/reva/pull/826
- https://github.com/cs3org/reva/pull/842

Now the chart deploys reva as a standalone pod (removing the additional gateway container) and exposing two services: HTTP and GRPC. If more revad pods are required, they can be deployed with the chart in the same fashion. 

Also move #4 (OC Dataprovider) to an entry in the [README](https://github.com/SamuAlfageme/charts/blob/57d31cacc0c150107c08ff628ed2d7ef4674e527/README.md#running-revad-as-dataprovider) with instructions on how to deploy it **on an existing IOP**.

### Contributing a Chart / update to an existing Chart

- [x] Run `helm lint` on the chart dir.
- [x] (Update) Bump the `Chart.yaml` version before merging, to release it as a new version.
