### PR TITLE
Extra volume mounts & environment variables

### DIFF
--- a/revad/Chart.yaml
+++ b/revad/Chart.yaml
@@ -1,8 +1,9 @@
+
 apiVersion: v2
 name: revad
 description: The Reva daemon (revad) helm chart
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: v0.1.0
 icon: https://reva.link/logo.svg
 home: https://reva.link

--- a/revad/README.md
+++ b/revad/README.md
@@ -40,6 +40,8 @@ The following configurations may be set. It is recommended to use `values.yaml` 
 | `service.http.port`                               | Revad's HTTP Service port. To be set on the `address` under the `[http]` section of the config.  | `19001`                                                                                                                 |
 | `configFiles.revad\.toml`                         | Revad [config file](https://reva.link/docs/config/). Mounted on `/etc/revad/`.                   | [`examples/standalone/standalone.toml`](https://github.com/cs3org/reva/blob/master/examples/standalone/standalone.toml) |
 | `configFiles.users\.json`                         | Revad `users.json` for the `auth_manager` and `userprovider` services. Mounted on `/etc/revad/`. | [`examples/standalone/users.demo.json`](https://github.com/cs3org/reva/blob/master/examples/standalone/users.demo.json) |
+| `extraVolumeMounts` | Array of additional volume mounts | `[]` |
+| `extraVolumes` | Array of additional volumes | `[]` |
 
 ### Deploying REVA with a `custom-config.toml` file
 

--- a/revad/README.md
+++ b/revad/README.md
@@ -42,6 +42,7 @@ The following configurations may be set. It is recommended to use `values.yaml` 
 | `configFiles.users\.json`                         | Revad `users.json` for the `auth_manager` and `userprovider` services. Mounted on `/etc/revad/`. | [`examples/standalone/users.demo.json`](https://github.com/cs3org/reva/blob/master/examples/standalone/users.demo.json) |
 | `extraVolumeMounts` | Array of additional volume mounts | `[]` |
 | `extraVolumes` | Array of additional volumes | `[]` |
+| `env` | Additional environment variables passed to the container | `[]`
 
 ### Deploying REVA with a `custom-config.toml` file
 

--- a/revad/templates/deployment.yaml
+++ b/revad/templates/deployment.yaml
@@ -40,6 +40,10 @@ spec:
             {{- if .Values.extraVolumeMounts }}
               {{ toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
+          {{- if .Values.env }}
+          env:
+              {{ toYaml .Values.env | nindent 12}}
+          {{- end }}
       volumes:
         - name: {{ include "revad.fullname" . }}-configfiles
           configMap:

--- a/revad/templates/deployment.yaml
+++ b/revad/templates/deployment.yaml
@@ -37,6 +37,9 @@ spec:
               mountPath: /etc/revad/
             - name: {{ include "revad.fullname" . }}-datadir
               mountPath: /var/tmp/reva/
+            {{- if .Values.extraVolumeMounts }}
+              {{ toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
       volumes:
         - name: {{ include "revad.fullname" . }}-configfiles
           configMap:
@@ -44,3 +47,6 @@ spec:
         # TODO(SamuAlfageme): allow PersistentVolmeClaim custom Value
         - name: {{ include "revad.fullname" . }}-datadir
           emptyDir: {}
+        {{- if .Values.extraVolumes }}
+          {{ toYaml .Values.extraVolumes | nindent 8}}
+        {{- end }}

--- a/revad/values.yaml
+++ b/revad/values.yaml
@@ -15,6 +15,8 @@ service:
 extraVolumeMounts: []
 extraVolumes: []
 
+env: []
+
 # https://reva.link/docs/config/
 configFiles:
   revad.toml: |

--- a/revad/values.yaml
+++ b/revad/values.yaml
@@ -12,6 +12,9 @@ service:
   http:
     port: 19001
 
+extraVolumeMounts: []
+extraVolumes: []
+
 # https://reva.link/docs/config/
 configFiles:
   revad.toml: |


### PR DESCRIPTION
This PR adds configurable extra volumes/volume mounts to the Reva charts.

**Background:** We at WWU need this to share files between Mentix (running in Reva) and Prometheus. Having the ability to configure extra volumes in `values.yaml` makes this much easier; right now, we have to manually modify the deployment charts.

**Example:** Extra volumes are configured like this in our case (in `values.yaml`):
```
...
extraVolumeMounts:
  - name: scrape-configs
    mountPath: /etc/revad/scrapes

extraVolumes:
  - name: scrape-configs
    persistentVolumeClaim:
      claimName: prom-shared-data
...
```
The Mentix service is then configured (in revad.yaml) to export to `/etc/revad/scrapes`.