### PR TITLE
[WIP] Enable 'revad' StatefulSet for stateful workloads (e.g. Storage Provider backends, etc)

### DIFF
--- a/revad/Chart.yaml
+++ b/revad/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: revad
 description: The Reva daemon (revad) helm chart
 type: application
-version: 1.2.2
+version: 1.2.4
 appVersion: v1.2.1
 icon: https://reva.link/logo.svg
 home: https://reva.link

--- a/revad/Chart.yaml
+++ b/revad/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: revad
 description: The Reva daemon (revad) helm chart
 type: application
-version: 1.2.0
-appVersion: v1.2.0
+version: 1.2.1
+appVersion: v1.2.1
 icon: https://reva.link/logo.svg
 home: https://reva.link
 source: https://github.com/cs3org/reva

--- a/revad/Chart.yaml
+++ b/revad/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: revad
 description: The Reva daemon (revad) helm chart
 type: application
-version: 1.2.1
+version: 1.2.2
 appVersion: v1.2.1
 icon: https://reva.link/logo.svg
 home: https://reva.link

--- a/revad/README.md
+++ b/revad/README.md
@@ -41,6 +41,7 @@ The following configurations may be set. It is recommended to use `values.yaml` 
 | `extraVolumeMounts`                               | Array of additional volume mounts.                                                                           | `[]`                                                                                                                    |
 | `extraVolumes`                                    | Array of additional volumes.                                                                                 | `[]`                                                                                                                    |
 | `emptyDir.sizeLimit`                              | `emptyDir` `sizeLimit` if a Persistent Volume is not used                                                    | `""`                                                                                                                    |
+| `useStatefulSet`                                  | If true, Revad will be deployed using a `StatefulSet` rather than the usual `Deployment`.                    | `false`                                                                                                                 |
 | `persistentVolume.enabled`                        | If true, Revad will create a Persistent Volume Claim.                                                        | `false`                                                                                                                 |
 | `persistentVolume.accessModes`                    | Revad data Persistent Volume access modes.                                                                   | `[ReadWriteOnce]`                                                                                                       |
 | `persistentVolume.annotations`                    | Revad data Persistent Volume annotations.                                                                    | `{}`                                                                                                                    |
@@ -61,4 +62,9 @@ The following configurations may be set. It is recommended to use `values.yaml` 
 ```console
 $ helm install custom-reva cs3org/revad \
   --set-file configFiles.revad\\.toml=custom-config.toml
+```
+
+### Stateful deployment
+
+```console
 ```

--- a/revad/templates/deployment.yaml
+++ b/revad/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           args:
               - "-c"
               {{- if .Values.useStatefulSet }}
-              - "/etc/revad/${HOSTNAME}.toml"
+              - "/etc/revad/$(HOSTNAME).toml"
               {{- else }}
               - "/etc/revad/revad.toml"
               {{- end }}
@@ -50,9 +50,17 @@ spec:
             {{- if .Values.extraVolumeMounts }}
               {{ toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
-          {{- if .Values.env }}
+          {{- if or .Values.env .Values.useStatefulSet }}
           env:
-              {{ toYaml .Values.env | nindent 12}}
+            {{- if .Values.useStatefulSet }}
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            {{- end }}
+            {{- if .Values.env }}
+            {{ toYaml .Values.env | nindent 12 }}
+            {{- end }}
           {{- end }}
       volumes:
         - name: {{ include "revad.fullname" . }}-configfiles

--- a/revad/templates/deployment.yaml
+++ b/revad/templates/deployment.yaml
@@ -34,7 +34,11 @@ spec:
             - /go/bin/revad
           args:
               - "-c"
+              {{- if .Values.useStatefulSet }}
+              - "/etc/revad/${HOSTNAME}.toml"
+              {{- else }}
               - "/etc/revad/revad.toml"
+              {{- end }}
               - "-p"
               - "/var/run/revad.pid"
           volumeMounts:

--- a/revad/templates/deployment.yaml
+++ b/revad/templates/deployment.yaml
@@ -1,10 +1,13 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: {{ if .Values.useStatefulSet }}{{ "StatefulSet" }}{{- else }}{{ "Deployment" }}{{- end }}
 metadata:
   name: {{ include "revad.fullname" . }}
   labels:
     {{- include "revad.labels" . | nindent 4 }}
 spec:
+  {{- if .Values.useStatefulSet }}
+  serviceName: {{ include "revad.fullname" . }}
+  {{- end }}
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
@@ -51,18 +54,40 @@ spec:
         - name: {{ include "revad.fullname" . }}-configfiles
           configMap:
             name: {{ template "revad.fullname" . }}-config
+      {{- if .Values.extraVolumes }}
+        {{ toYaml .Values.extraVolumes | nindent 8 }}
+      {{- end }}
+    {{- if .Values.persistentVolume.enabled }}
+      {{- if .Values.useStatefulSet }}
+  volumeClaimTemplates:
+    - metadata:
+        name: {{ include "revad.fullname" . }}-datadir
+        {{- if .Values.persistentVolume.annotations }}
+        annotations:
+          {{- toYaml .Values.persistentVolume.annotations | indent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+          {{- toYaml .Values.persistentVolume.accessModes | indent 10 }}
+        resources:
+          requests: 
+            storage: "{{ .Values.persistentVolume.size }}"
+          {{- if (eq "-" .Values.persistentVolume.storageClass) }}
+            storageClassName: ""
+          {{- else }}
+            storageClassName: "{{ .Values.persistentVolume.storageClass }}"
+          {{- end }}
+      {{- else }}
         - name: {{ include "revad.fullname" . }}-datadir
-        {{- if .Values.persistentVolume.enabled }}
           persistentVolumeClaim:
             claimName: {{ if .Values.persistentVolume.existingClaim }}{{ .Values.persistentVolume.existingClaim }}{{- else }}{{ template "revad.fullname" . }}{{- end }}
-        {{- else }}
+      {{- end }}
+    {{- else }}
+        - name: {{ include "revad.fullname" . }}-datadir
           emptyDir:
           {{- if .Values.emptyDir.sizeLimit }}
             sizeLimit: {{ .Values.emptyDir.sizeLimit }}
           {{- else }}
             {}
           {{- end -}}
-        {{- end -}}
-        {{- if .Values.extraVolumes }}
-          {{ toYaml .Values.extraVolumes | nindent 8 }}
-        {{- end }}
+    {{- end }}

--- a/revad/templates/service.yaml
+++ b/revad/templates/service.yaml
@@ -5,7 +5,11 @@ metadata:
   labels:
     {{- include "revad.labels" . | nindent 4 }}
 spec:
+  {{- if .Values.useStatefulSet }}
+  clusterIP: None
+  {{- else }}
   type: {{ .Values.service.type }}
+  {{- end }}
   ports:
     {{- if .Values.service.http }}
     - port: {{ .Values.service.http.port }}

--- a/revad/values.yaml
+++ b/revad/values.yaml
@@ -18,6 +18,8 @@ extraVolumes: []
 emptyDir:
   sizeLimit: ""
 
+useStatefulSet: false
+
 persistentVolume:
   ## If true, revad will create/use a Persistent Volume Claim
   ## If false, use emptyDir


### PR DESCRIPTION
**Creating as WIP for the moment as it needs careful regression testing for previous deployments. Version `1.2.4` is temporary.**

This deployment is useful when multiple instances on Revad with [unique, distinct features](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#using-statefulsets) (like e.g. unique network identifiers and/or config files). 

So far, we use `revad.configFiles` as a dictionary holding the the unique config files, based on the pod's `HOSTNAME`  (no automated generation via `initContainer` just yet).

### Contributing a Chart / update to an existing Chart

- [x] Run `helm lint` on the chart dir.
- [ ] (Update) Bump the `Chart.yaml` version before merging, to release it as a new version.
- [x] (Update) If the PR includes new configurable parameters in the chart's `values.yaml`. Add documentation in the appropiate README.
