### PR TITLE
Fix: check for the 'ingress' resource, rather than the API itself

### DIFF
--- a/revad/Chart.yaml
+++ b/revad/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: revad
 description: The Reva daemon (revad) helm chart
 type: application
-version: 1.3.0
+version: 1.3.1
 appVersion: v1.7.0
 kubeVersion: ">= 1.14.0"
 icon: https://reva.link/logo.svg
@@ -23,11 +23,7 @@ keywords:
   - sync-and-share
 annotations:
   artifacthub.io/changes: |
-    - "Add the ingress resource templates from sciencemesh/iop"
-    - "Generate the right 'apiVersion' for ingress resources when using k8s versions >= 1.19"
-    - "Explicitly drop support for Kubernetes versions older than 1.14"
-    - "Bump revad's version to v1.7.0"
-    - "Add maintainters to the chart"
+    - "Fix: check for the 'ingress' resource, rather than the API itself"
   artifacthub.io/images: |
     - name: revad
       image: cs3org/revad:v1.7.0

--- a/revad/templates/_helpers.tpl
+++ b/revad/templates/_helpers.tpl
@@ -55,8 +55,8 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{/*
 Return the appropriate apiVersion for ingress.
 */}}
-{{- define "revad.ingressapiVersion" -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- define "revad.ingress.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/ingress" }}
 {{- print "networking.k8s.io/v1" -}}
 {{- else }}
 {{- print "networking.k8s.io/v1beta1" -}}

--- a/revad/templates/ingress.yaml
+++ b/revad/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled }}
 {{- range $service, $ingress := .Values.ingress.services }}
-apiVersion: {{ template "revad.ingressapiVersion" $ }}
+apiVersion: {{ template "revad.ingress.apiVersion" $ }}
 kind: Ingress
 metadata:
   name: {{ template "revad.fullname" $ }}-{{ $service }}

--- a/wopiserver/Chart.yaml
+++ b/wopiserver/Chart.yaml
@@ -2,12 +2,13 @@ apiVersion: v2
 name: wopiserver
 description: A Vendor-neutral Web-application Open Platform Interface (WOPI) gateway for EFSS systems
 type: application
-version: 0.2.3
-appVersion: 6.5.0
+version: 0.2.4
+appVersion: v6.5.0
 kubeVersion: ">= 1.14.0"
 home: https://github.com/cs3org/wopiserver
 sources:
   - https://github.com/cs3org/wopiserver
+  - https://github.com/cs3org/wopibridge
 maintainers:
   - name: SamuAlfageme
     email: samuel.alfageme.sainz@cern.ch
@@ -18,11 +19,7 @@ keywords:
   - efss
 annotations:
   artifacthub.io/changes: |
-    - "Fix WOPI Server, Bridge version in Chart.yaml"
-    - "Rename 'revahost' to 'revagateway' in WOPI Server config"
-    - "Set 'CODIMD_{INT,EXT}_URL' explicit placeholders to prevent WB CrashLoopBackOff"
-    - "Add 'codimd_apikey' shared Secret to the WOPI Bridge deployment"
-    - "Generate the right 'apiVersion' for ingress resources when using k8s versions >= 1.19"
+    - "Fix: check for the 'ingress' resource, rather than the API itself"
   artifacthub.io/images: |
     - name: wopiserver
       image: cs3org/wopiserver:v6.5.0

--- a/wopiserver/templates/_helpers.tpl
+++ b/wopiserver/templates/_helpers.tpl
@@ -67,7 +67,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Return the appropriate apiVersion for ingress.
 */}}
 {{- define "wopiserver.ingress.apiVersion" -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/ingress" }}
 {{- print "networking.k8s.io/v1" -}}
 {{- else }}
 {{- print "networking.k8s.io/v1beta1" -}}


### PR DESCRIPTION
Prevents the error reported in https://github.com/sciencemesh/charts/pull/15#pullrequestreview-655892185 when the ingress resource is not present on the cluster

### Contributing a Chart / update to an existing Chart

- [x] Run `helm lint` on the chart dir.
- [x] (Update) Bump the `Chart.yaml` version before merging, to release it as a new version.
- [ ] ~(Update) If the PR includes new configurable parameters in the chart's `values.yaml`. Add documentation in the appropiate README.~
