### PR TITLE
Bump WOPI components version to work with newest MeshApps chart

### DIFF
--- a/wopiserver/Chart.yaml
+++ b/wopiserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: wopiserver
 description: A Vendor-neutral Web-application Open Platform Interface (WOPI) gateway for EFSS systems
 type: application
-version: 0.2.4
-appVersion: v6.5.0
+version: 0.3.0
+appVersion: v6.7.0
 kubeVersion: ">= 1.14.0"
 home: https://github.com/cs3org/wopiserver
 sources:
@@ -19,10 +19,10 @@ keywords:
   - efss
 annotations:
   artifacthub.io/changes: |
-    - "Fix: check for the 'ingress' resource, rather than the API itself"
+    - "Increase pinned versions to improve compatibility with sciencemes/MeshApps@0.1.0"
   artifacthub.io/images: |
     - name: wopiserver
-      image: cs3org/wopiserver:v6.5.0
+      image: cs3org/wopiserver:v6.7.0
     - name: wopibridge
-      image: cs3org/wopibridge:v3.2.0
+      image: cs3org/wopibridge:v4.0.0
   artifacthub.io/containsSecurityUpdates: "false"

--- a/wopiserver/values.yaml
+++ b/wopiserver/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: cs3org/wopiserver
-  tag: v6.5.0
+  tag: v6.7.0
   pullPolicy: Always
 
 service:
@@ -45,7 +45,7 @@ wopibridge:
   replicaCount: 1
   image:
     repository: cs3org/wopibridge
-    tag: v3.2.0
+    tag: v4.0.0
     pullPolicy: Always
 
   service:


### PR DESCRIPTION
### Contributing a Chart / update to an existing Chart

- [x] Run `helm lint` on the chart dir.
- [x] (Update) Bump the `Chart.yaml` version before merging, to release it as a new version.
- [ ] ~~(Update) If the PR includes new configurable parameters in the chart's `values.yaml`. Add documentation in the appropiate README.~~
