### PR TITLE
Update revad version and entrypoint

### DIFF
--- a/revad/Chart.yaml
+++ b/revad/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: revad
 description: The Reva daemon (revad) helm chart
 type: application
-version: 1.3.1
-appVersion: v1.7.0
+version: 1.3.2
+appVersion: v1.9.0
 kubeVersion: ">= 1.14.0"
 icon: https://reva.link/logo.svg
 home: https://reva.link
@@ -23,7 +23,7 @@ keywords:
   - sync-and-share
 annotations:
   artifacthub.io/changes: |
-    - "Fix: check for the 'ingress' resource, rather than the API itself"
+    - "Update revad image to v1.9.0 and modify the entrypoint accordingly"
   artifacthub.io/images: |
     - name: revad
-      image: cs3org/revad:v1.7.0
+      image: cs3org/revad:v1.9.0

--- a/revad/templates/deployment.yaml
+++ b/revad/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
               containerPort: {{ .Values.service.grpc.port }}
               protocol: TCP
           command:
-            - /go/bin/revad
+            - /usr/bin/revad
           args:
               - "-c"
               - "/etc/revad/revad.toml"

--- a/revad/values.yaml
+++ b/revad/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: cs3org/revad
-  tag: v1.7.0
+  tag: v1.9.0
   pullPolicy: Always
 
 service:


### PR DESCRIPTION
Draft until https://github.com/cs3org/reva/pull/1797 is merged and `v1.9.0` is released

### Contributing a Chart / update to an existing Chart

- [x] Run `helm lint` on the chart dir.
- [x] (Update) Bump the `Chart.yaml` version before merging, to release it as a new version.
- [ ] ~~(Update) If the PR includes new configurable parameters in the chart's `values.yaml`. Add documentation in the appropiate README.~~
