### PR TITLE
remove Ingress api version switch logic

### DIFF
--- a/revad/Chart.yaml
+++ b/revad/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: revad
 description: The Reva daemon (revad) helm chart
 type: application
-version: 1.3.3
+version: 1.4.0
 appVersion: v1.18.0
-kubeVersion: ">= 1.14.0"
+kubeVersion: ">= 1.19.0"
 icon: https://reva.link/logo.svg
 home: https://reva.link
 sources:

--- a/revad/templates/_helpers.tpl
+++ b/revad/templates/_helpers.tpl
@@ -51,18 +51,6 @@ app.kubernetes.io/name: {{ include "revad.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
-
-{{/*
-Return the appropriate apiVersion for ingress.
-*/}}
-{{- define "revad.ingress.apiVersion" -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/ingress" }}
-{{- print "networking.k8s.io/v1" -}}
-{{- else }}
-{{- print "networking.k8s.io/v1beta1" -}}
-{{- end }}
-{{- end -}}
-
 {{/*
 Create the name of the service account to use
 */}}

--- a/revad/templates/ingress.yaml
+++ b/revad/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled }}
 {{- range $service, $ingress := .Values.ingress.services }}
-apiVersion: {{ template "revad.ingress.apiVersion" $ }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "revad.fullname" $ }}-{{ $service }}
@@ -17,16 +17,11 @@ spec:
         paths:
           - path: {{ $ingress.path }}
             backend:
-            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/ingress" }}
               service:
                 name: {{ template "revad.fullname" $ }}
                 port:
                   name: {{ $service }}
             pathType: ImplementationSpecific
-            {{- else }}
-              serviceName: {{ template "revad.fullname" $ }}
-              servicePort: {{ $service }}
-            {{- end }}
     {{- end }}
   {{- if $ingress.tls }}
   tls:

--- a/wopiserver/Chart.yaml
+++ b/wopiserver/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: wopiserver
 description: A Vendor-neutral Web-application Open Platform Interface (WOPI) gateway for EFSS systems
 type: application
-version: 0.3.0
+version: 0.4.0
 appVersion: v6.7.0
-kubeVersion: ">= 1.14.0"
+kubeVersion: ">= 1.19.0"
 home: https://github.com/cs3org/wopiserver
 sources:
   - https://github.com/cs3org/wopiserver

--- a/wopiserver/templates/_helpers.tpl
+++ b/wopiserver/templates/_helpers.tpl
@@ -64,17 +64,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{/*
-Return the appropriate apiVersion for ingress.
-*/}}
-{{- define "wopiserver.ingress.apiVersion" -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/ingress" }}
-{{- print "networking.k8s.io/v1" -}}
-{{- else }}
-{{- print "networking.k8s.io/v1beta1" -}}
-{{- end }}
-{{- end -}}
-
-{{/*
 Returns the WOPI Server external URL
 */}}
 {{- define "wopiserver.url" -}}

--- a/wopiserver/templates/ingress.yaml
+++ b/wopiserver/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled }}
-apiVersion: {{ template "wopiserver.ingress.apiVersion" . }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "wopiserver.fullname" . }}
@@ -16,16 +16,11 @@ spec:
         paths:
           - path: {{ .Values.ingress.path }}
             backend:
-            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/ingress" }}
               service:
                 name: {{ template "wopiserver.fullname" . }}
                 port:
                   name: http
             pathType: ImplementationSpecific
-            {{- else }}
-              serviceName: {{ template "wopiserver.fullname" . }}
-              servicePort: http
-            {{- end }}
     {{- end }}
   {{- if .Values.ingress.tls }}
   tls:

--- a/wopiserver/templates/wopibridge/ingress.yaml
+++ b/wopiserver/templates/wopibridge/ingress.yaml
@@ -1,6 +1,6 @@
 {{- with .Values.wopibridge }}
 {{- if and .enabled .ingress.enabled }}
-apiVersion: {{ template "wopiserver.ingress.apiVersion" $ }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "wopiserver.fullname" $ }}-{{ .name }}
@@ -17,16 +17,11 @@ spec:
         paths:
           - path: {{ .ingress.path }}
             backend:
-            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/ingress" }}
               service:
                 name: {{ template "wopiserver.fullname" $ }}-{{ .name }}
                 port:
                   name: http
             pathType: ImplementationSpecific
-            {{- else }}
-              serviceName: {{ template "wopiserver.fullname" $ }}-{{ .name }}
-              servicePort: http
-            {{- end }}
     {{- end }}
   {{- if .ingress.tls }}
   tls:


### PR DESCRIPTION
This PR removes the Ingres apiVersion switch logic.

Ingress from networking.k8s.io/v1 is available from Kubernetes v1.19 on.
v1.19 had it's EOL on 2021-10-28 (https://kubernetes.io/releases/patch-releases/#non-active-branch-history), therefore there is no need to longer support networking.k8s.io/v1beta1.


### Contributing a Chart / update to an existing Chart

- [x] Run `helm lint` on the chart dir.
- [x] (Update) Bump the `Chart.yaml` version before merging, to release it as a new version.
- [ ] (Update) If the PR includes new configurable parameters in the chart's `values.yaml`. Add documentation in the appropiate README.
