### PR TITLE
Add IDP service chart

### DIFF
--- a/idp/.helmignore
+++ b/idp/.helmignore
@@ -1,0 +1,25 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# chart-testing-action configurations
+ci/

--- a/idp/Chart.yaml
+++ b/idp/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: idp
+description: CS3 APIs compatible OIDC Identity provider based on OCIS
+type: application
+version: 0.1.0
+appVersion: v2.0.0-beta.8
+kubeVersion: '>= 1.19.0'
+home: https://github.com/owncloud/ocis
+sources:
+  - https://github.com/owncloud/ocis
+maintainers:
+  - name: Miroslav Bauer
+    email: bauer@cesnet.cz
+keywords:
+  - oidc
+  - idp
+  - identity
+  - provider
+  - cs3
+annotations:
+  artifacthub.io/images: |
+    - name: ocis
+      image: owncloud/ocis:2.0.0-beta.8
+  artifacthub.io/containsSecurityUpdates: 'false'

--- a/idp/README.md
+++ b/idp/README.md
@@ -1,0 +1,64 @@
+# IDP service
+
+An OpenID Connect Identity Provider service compatible with CS3 APIs based on OCIS IDP implementation.
+
+## Introduction
+
+This chart creates a deployment of [OCIS IDP](https://owncloud.dev/services/idp/) service on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager. The IDP service is configured to use a CS3APIs compliant service (e.g. Reva) as its user info & authentication backend.
+
+## Install
+
+To install the chart with the release name `my-idp`:
+
+```console
+helm install my-idp cs3org/idp
+```
+
+> **WARNING**: Install command will generate (or overwrite already existing) signing and encryption keys for the IDP, if those are not provided explicitly in the `values.yaml` file.
+
+## Uninstalling the Chart
+
+To uninstall/delete the deployment:
+
+```console
+helm delete my-idp
+```
+
+## Configuration
+
+The following configurations may be set. It is recommended to use `values.yaml` for overwriting the IDP config.
+
+| Parameter                    | Description                                                                                   | Default                                                   |
+| ---------------------------- | --------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| `log.level`                  | The log level. Valid values are: “panic”, “fatal”, “error”, “warn”, “info”, “debug”, “trace”. | error                                                     |
+| `log.color`                  | Activates colorized log output.                                                               | false                                                     |
+| `log.pretty`                 | Activates pretty log output.                                                                  | false                                                     |
+| `idp.issuerURI`              | External url of the IDP service, used in token issuer field                                   | <http://idp:9130>                                         |
+| `idp.accessTokenValidity`    | Expiration time in seconds for IDP access token.                                              | 86400                                                     |
+| `idp.idTokenValidity`        | Expiration time in seconds for IDP ID tokens.                                                 | 3600                                                      |
+| `idp.refreshTokenValidity`   | Expiration time in seconds for refresh tokens.                                                | 94608000                                                  |
+| `idp.clients`                | Registered OpenID Connect clients configuration                                               | `[{name: 'ownCloud desktop app', ...}]`                   |
+| `cs3.gateway`                | CS3 gateway used to authenticate and look up users                                            | revad:19000                                               |
+| `extraResources`             | Extra resources to be included.                                                               | `[]`                                                      |
+| `image.pullPolicy`           | The kubernetes image pull policy.                                                             | `IfNotPresent`                                            |
+| `image.repository`           | Name of the image to run, without the tag.                                                    | [`owncloud/ocis`](https://hub.docker.com/r/owncloud/ocis) |
+| `image.tag`                  | The image tag to use.                                                                         | `v8.3.2`                                                  |
+| `ingress.annotations`        | Ingress annotations.                                                                          | `{}`                                                      |
+| `ingress.enabled`            | Whether to create an Ingress resource to access the wopiserver.                               | `false`                                                   |
+| `ingress.hostname`           | The ingress hostname.                                                                         | `idp.local`                                               |
+| `ingress.path`               | The ingress path.                                                                             | `/`                                                       |
+| `ingress.tls`                | Ingress TLS configuration (YAML).                                                             | `[]`                                                      |
+| `replicaCount`               | How many replicas to run.                                                                     | `1`                                                       |
+| `resources`                  | Resources to apply to all services.                                                           | `{}`                                                      |
+| `secretsRef`                 | Use an already existing secret instead of configuring the `secrets` settings.                 | `nil`                                                     |
+| `securityContext.fsGroup`    | File system group for all volumes.                                                            | `1000`                                                    |
+| `securityContext.runAsGroup` | Group ID that all processes within any containers will run with.                              | `1000`                                                    |
+| `securityContext.runAsUser`  | User ID that all processes within any containers will run with.                               | `1000`                                                    |
+| `service.port`               | The wopiserver service HTTP port.                                                             | `8880`                                                    |
+| `service.type`               | The Kubernetes service type to use.                                                           | `ClusterIP`                                               |
+
+> **NOTE**: This service requires atlest one `idp.clients` to be registered in order to boot properly.
+
+## Register with Sciencemesh Proxy IDP portal
+
+Before your IDP service can appear in the Sciencemesh [Proxy IDP portal](http://aai-demo.sciencemesh.cesnet.cz/.well-known/openid-configuration), you will need to register it by contacting CESNET administrators with your `idp.issuerURL` and to register Proxy IDP portal client in your `idp.clients` config.

--- a/idp/templates/_helpers.tpl
+++ b/idp/templates/_helpers.tpl
@@ -72,8 +72,8 @@ If the Secret config does not exist, the pod will hang due to missing mount.
 Returns the WOPI Server external URL
 */}}
 {{- define "idp.url" -}}
-  {{- if .Values.idp.issuerURI -}}
-    {{- .Values.idp.issuerURI }}
+  {{- if .Values.config.idp.issuerURI -}}
+    {{- .Values.config.idp.issuerURI }}
   {{- else }}
     {{- if .Values.ingress.hostname -}}
       {{- if .Values.ingress.tls -}}

--- a/idp/templates/_helpers.tpl
+++ b/idp/templates/_helpers.tpl
@@ -1,0 +1,88 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "idp.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "idp.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "idp.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "idp.labels" -}}
+helm.sh/chart: {{ include "idp.chart" . }}
+{{ include "idp.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "idp.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "idp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+
+{{/*
+Name of the configMap storing the IDP configuration
+Returns:
+  - the name of the secret-based config passed as .Values.cfgmapName
+  - "<release_fullname>-config-secret" by default.
+If the Secret config does not exist, the pod will hang due to missing mount.
+*/}}
+{{- define "idp.cfgmapName" -}}
+{{- if .Values.cfgmapName }}
+{{- printf "%s" .Values.cfgmapName }}
+{{- else }}
+{{- printf "%s%s" (include "idp.fullname" .) "-config-secret" }}
+{{- end }}
+{{- end }}
+
+
+{{/*
+Returns the WOPI Server external URL
+*/}}
+{{- define "idp.url" -}}
+  {{- if .Values.idp.issuerURI -}}
+    {{- .Values.idp.issuerURI }}
+  {{- else }}
+    {{- if .Values.ingress.hostname -}}
+      {{- if .Values.ingress.tls -}}
+        https://{{ .Values.ingress.hostname }}
+      {{- else -}}
+        http://{{ .Values.ingress.hostname }}
+      {{- end -}}
+    {{- else -}}
+        http://{{ template "idp.fullname" . }}:{{ .Values.service.port }}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}

--- a/idp/templates/_tplvalues.tpl
+++ b/idp/templates/_tplvalues.tpl
@@ -1,0 +1,13 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" .) }}
+*/}}
+{{- define "common.tplvalues.render" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}

--- a/idp/templates/deployment.yaml
+++ b/idp/templates/deployment.yaml
@@ -1,0 +1,115 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "idp.fullname" . }}
+  labels:
+    {{- include "idp.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "idp.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      labels:
+        {{- include "idp.selectorLabels" . | nindent 8 }}
+    spec:
+      securityContext:
+          fsGroup: {{ $.Values.securityContext.fsGroup }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: {{ $.Values.securityContext.runAsUser }}
+            runAsGroup: {{ $.Values.securityContext.runAsGroup }}
+            readOnlyRootFilesystem: true
+          resources: {{ toYaml $.Values.resources | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /.well-known/openid-configuration
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /.well-known/openid-configuration
+              port: http
+          command:
+            - /usr/bin/ocis
+          args:
+              - "idp"
+              - "server"
+          volumeMounts:
+            - name: {{ include "idp.fullname" . }}-config-tmp
+              # we mount that volume only to apply fsGroup to that path
+              mountPath: /etc/ocis
+            - name: {{ include "idp.fullname" . }}-data-tmp
+              # we mount that volume to apply fsGroup to that path, so that the idp can write the temporary idp/tmp/identifier-registration.yaml file
+              mountPath: /var/lib/ocis 
+            - name: {{ include "idp.fullname" . }}-configfiles
+              mountPath: /etc/ocis/idp
+              readOnly: true
+            - name: {{ include "idp.fullname" . }}-secrets
+              mountPath: /etc/ocis/idp/encryption.key
+              subPath: encryption.key
+              readOnly: true
+            - name: {{ include "idp.fullname" . }}-secrets
+              mountPath: /etc/ocis/idp/private-key.pem
+              subPath: private-key.pem
+              readOnly: true
+            {{- if .Values.extraVolumeMounts }}
+              {{ toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+          env:
+            - name: IDP_MACHINE_AUTH_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  {{ if .Values.secretsRef }}
+                  name: {{ .Values.secretsRef }}
+                  {{ else }}
+                  name: {{ template "idp.fullname" . }}-secrets
+                  {{ end }}
+                  key: machineAuthApiKey
+          {{- if .Values.extraEnv }}
+            {{- toYaml .Values.extraEnv | nindent 12 }}
+          {{- end }}
+          {{- if .Values.envFrom }}
+          envFrom:
+            {{ toYaml .Values.envFrom | indent 12 }}
+          {{- end }}
+      volumes:
+        - name: {{ include "idp.fullname" . }}-configfiles
+          secret:
+            secretName: {{ include "idp.cfgmapName" . }}
+        - name: {{ include "idp.fullname" . }}-config-tmp
+          emptyDir:
+            medium: Memory
+          {{- if .Values.emptyDir.sizeLimit }}
+            sizeLimit: {{ .Values.emptyDir.sizeLimit }}
+          {{- else }}
+            sizeLimit: 6Mi
+          {{- end -}}
+        - name: {{ include "idp.fullname" . }}-data-tmp
+          emptyDir:
+            medium: Memory
+            {{- if .Values.emptyDir.sizeLimit }}
+            sizeLimit: {{ .Values.emptyDir.sizeLimit }}
+            {{- else }}
+            sizeLimit: 6Mi
+            {{- end -}}
+        - name: {{ include "idp.fullname" . }}-secrets
+          secret:
+            {{ if .Values.secretsRef }}
+            secretName: {{ .Values.secretsRef }}
+            {{ else }}
+            secretName: {{ template "idp.fullname" . }}-secrets
+            {{ end }}
+        {{- if .Values.extraVolumes }}
+          {{ toYaml .Values.extraVolumes | nindent 8 }}
+        {{- end }}

--- a/idp/templates/deployment.yaml
+++ b/idp/templates/deployment.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
       labels:
         {{- include "idp.selectorLabels" . | nindent 8 }}
     spec:

--- a/idp/templates/deployment.yaml
+++ b/idp/templates/deployment.yaml
@@ -94,7 +94,7 @@ spec:
             sizeLimit: {{ .Values.emptyDir.sizeLimit }}
           {{- else }}
             sizeLimit: 6Mi
-          {{- end -}}
+          {{- end }}
         - name: {{ include "idp.fullname" . }}-data-tmp
           emptyDir:
             medium: Memory
@@ -102,7 +102,7 @@ spec:
             sizeLimit: {{ .Values.emptyDir.sizeLimit }}
             {{- else }}
             sizeLimit: 6Mi
-            {{- end -}}
+            {{- end }}
         - name: {{ include "idp.fullname" . }}-secrets
           secret:
             {{ if .Values.secretsRef }}

--- a/idp/templates/extra-resources.yaml
+++ b/idp/templates/extra-resources.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraResources }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/idp/templates/ingress.yaml
+++ b/idp/templates/ingress.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ template "idp.fullname" . }}
+  labels: {{- include "idp.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.ingress.annotations }}
+{{ toYaml .Values.ingress.annotations | indent 4 }}
+    {{- end }}
+spec:
+  rules:
+    {{- if .Values.ingress.hostname }}
+    - host: {{ .Values.ingress.hostname }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            backend:
+              service:
+                name: {{ template "idp.fullname" . }}
+                port:
+                  name: http
+            pathType: ImplementationSpecific
+    {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end }}
+{{- end }}

--- a/idp/templates/secrets.yaml
+++ b/idp/templates/secrets.yaml
@@ -24,7 +24,7 @@ data:
   {{ if .Values.secrets.privateKey }}
   private-key.pem: "{{ $.Files.Get .Values.secrets.privateKey | b64enc }}"
   {{ else }}
-  private-key.pem: "{{ genPrivateKey rsa | b64enc }}"
+  private-key.pem: "{{ genPrivateKey "rsa" | b64enc }}"
   {{ end }}
 {{ end }}
 
@@ -43,23 +43,23 @@ data:
       signing_private_key_files:
         - /etc/ocis/idp/private-key.pem
       encrypt_secret_file: /etc/ocis/idp/encryption.key
-      access_token_duration_seconds: {{ .Values.idp.accessTokenValidity }}
-      id_token_duration_seconds: {{ .Values.idp.idTokenValidity }}
-      refresh_token_duration_seconds: {{ .Values.idp.refreshTokenValidity }}
-      {{- if .Values.idp.clients }}
+      access_token_duration_seconds: {{ .Values.config.idp.accessTokenValidity }}
+      id_token_duration_seconds: {{ .Values.config.idp.idTokenValidity }}
+      refresh_token_duration_seconds: {{ .Values.config.idp.refreshTokenValidity }}
+      {{- if .Values.config.idp.clients }}
       clients:
-      {{ toYaml .Values.idp.clients | indent 2 }}
+      {{ toYaml .Values.config.idp.clients | indent 2 }}
       {{ else }}
       clients: []
       {{- end }}
     http: 
       addr: 0.0.0.0:{{ .Values.service.port }}
     reva:
-      address: {{ .Values.cs3.gateway }}
+      address: {{ .Values.config.cs3.gateway }}
     log:
-      level: "{{ .Values.log.level }}"
-      pretty: {{ .Values.log.pretty }}
-      color: {{ .Values.log.color }}
+      level: "{{ .Values.config.log.level }}"
+      pretty: {{ .Values.config.log.pretty }}
+      color: {{ .Values.config.log.color }}
     auth_bearer:
       auth_providers:
         oidc:

--- a/idp/templates/secrets.yaml
+++ b/idp/templates/secrets.yaml
@@ -1,0 +1,68 @@
+{{ if not .Values.secretsRef }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "idp.fullname" . }}-secrets
+  labels:
+    {{- include "idp.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+type: Opaque
+data:
+  {{ if .Values.secrets.machineAuthApiKey }}
+  machineAuthApiKey: "{{ .Values.secrets.machineAuthApiKey | b64enc }}"
+  {{ else }}
+  machineAuthApiKey: "{{ randAlphaNum 50 | b64enc }}"
+  {{ end }}
+  {{ if .Values.secrets.encryptionKey }}
+  encryption.key: "{{ .Values.secrets.encryptionKey | b64enc }}"
+  {{ else }}
+  encryption.key: "{{ randBytes 32 }}"
+  {{ end }}
+  {{ if .Values.secrets.privateKey }}
+  private-key.pem: "{{ $.Files.Get .Values.secrets.privateKey | b64enc }}"
+  {{ else }}
+  private-key.pem: "{{ genPrivateKey rsa | b64enc }}"
+  {{ end }}
+{{ end }}
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "idp.fullname" . }}-config-secret
+  labels:
+    {{- include "idp.labels" . | nindent 4 }}
+data:
+  ocis.yaml: |
+    idp:
+      iss: {{ include "idp.url" . }}
+      identity_manager: cs3
+      signing_private_key_files:
+        - /etc/ocis/idp/private-key.pem
+      encrypt_secret_file: /etc/ocis/idp/encryption.key
+      access_token_duration_seconds: {{ .Values.idp.accessTokenValidity }}
+      id_token_duration_seconds: {{ .Values.idp.idTokenValidity }}
+      refresh_token_duration_seconds: {{ .Values.idp.refreshTokenValidity }}
+      {{- if .Values.idp.clients }}
+      clients:
+      {{ toYaml .Values.idp.clients | indent 2 }}
+      {{ else }}
+      clients: []
+      {{- end }}
+    http: 
+      addr: 0.0.0.0:{{ .Values.service.port }}
+    reva:
+      address: {{ .Values.cs3.gateway }}
+    log:
+      level: "{{ .Values.log.level }}"
+      pretty: {{ .Values.log.pretty }}
+      color: {{ .Values.log.color }}
+    auth_bearer:
+      auth_providers:
+        oidc:
+          insecure: false
+    proxy:
+      insecure_backends: false

--- a/idp/templates/service.yaml
+++ b/idp/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "idp.fullname" . }}
+  labels:
+    {{- include "idp.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "idp.selectorLabels" . | nindent 4 }}

--- a/idp/values.yaml
+++ b/idp/values.yaml
@@ -1,0 +1,109 @@
+replicaCount: 1
+
+image:
+  repository: owncloud/ocis
+  tag: 2.0.0-beta.8
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 9130
+
+# IDP service configuration reference
+# - ref: https://owncloud.dev/services/idp/
+extraEnv: {}
+config:
+  log:
+    level: error
+    color: false
+    pretty: false
+  cs3:
+    gateway: revad:19000
+  idp:
+    # External url of the IDP service, used in token issuer field
+    # issuerURI: https://external-idp-url.example
+    accessTokenValidity: 86400
+    idTokenValidity: 3600
+    refreshTokenValidity: 94608000
+    # List of OIDC clients allowed to use the IDP service
+    clients:
+      # NOTE: After you add your own clients, you can safely remove this one.
+      # It is here because IDP service refuses to boot without any registered clients.
+      - id: xdXOt13JKxym1B1QcEncf2XDkLAexMBFwiT9j6EfhhHFJhs2KM9jbjTmf8JBXE69
+        name: ownCloud desktop app
+        trusted: false
+        secret: UBntmLjC2yYCeHwsyj73Uwo9TAaecAetRwMw0xYcvNL9yRdLSUi0hUAHfvCHFeFh
+        redirect_uris:
+          - http://127.0.0.1
+          - http://localhost
+        origins: []
+        application_type: native
+    # NOTE: Before you can use your IDP service with the ScienceMesh proxy IDP
+    # portal, you first need to obtain your <client-id> and <client-secret> from
+    # the portal administrators @ CESNET.
+    #
+    # - id: <client-id>
+    #   name: ScienceMesh proxy IDP portal
+    #   trusted: true
+    #   secret: <client-secret>
+    #   insecure: false
+    #   redirect_uris:
+    #     - https://aai-demo.sciencemesh.cesnet.cz/callback
+    #   origins: []
+    #   application_type: ''
+
+# secretRef allows one to use an already existing secret instead of configuring the secrets below
+secretsRef:
+# secrets are only used if "secretRef" is not set or empty
+secrets:
+  # machineAuthApiKey:
+  # NOTE: example generation command: `tr -cd '[a-zA-Z0-9],.' < /dev/urandom | fold -w 50 | head -n 1 | tr -d '\n' | base64`
+  #
+  # encryptionKey: random 32-byte long, base64 encoded string
+  # NOTE: example generation command: `openssl rand 32 | base64`
+  #
+  # privateKey: /path/to/private-key.pem
+  # how to generate: base64 encode a private key (eg. RSA, ensure that you use reasonable long key size)
+  # example generation command: `openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:4096 2> /dev/null > private-key.pem`
+
+# Security context options.
+securityContext:
+  # -- File system group for all volumes.
+  fsGroup: 1000
+  # -- User ID that all processes within any containers will run with.
+  runAsUser: 1000
+  # -- Group ID that all processes within any containers will run with.
+  runAsGroup: 1000
+
+ingress:
+  enabled: false
+  hostname: idp.local
+  path: /
+  annotations:
+    {}
+    # kubernetes.io/ingress.class: nginx
+    # nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  tls:
+    []
+    # Secrets must be present in the namespace beforehand.
+    # - secretName: idp-tls
+    #   hosts:
+    #     - idp.local
+
+# -- Resources to apply to all services.
+resources:
+  {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# Include arbitrary resources, eg. config maps or secrets.
+# -- Extra resources to be included.
+extraResources: []
+
+# Mount arbitrary volumes to the pod.
+# -- Extra volume mounts to be used.
+extraVolumeMounts: {}

--- a/idp/values.yaml
+++ b/idp/values.yaml
@@ -56,6 +56,7 @@ config:
 secretsRef:
 # secrets are only used if "secretRef" is not set or empty
 secrets:
+  {}
   # machineAuthApiKey:
   # NOTE: example generation command: `tr -cd '[a-zA-Z0-9],.' < /dev/urandom | fold -w 50 | head -n 1 | tr -d '\n' | base64`
   #
@@ -107,3 +108,5 @@ extraResources: []
 # Mount arbitrary volumes to the pod.
 # -- Extra volume mounts to be used.
 extraVolumeMounts: {}
+
+emptyDir: {}


### PR DESCRIPTION
Adds a deployment Chart of an OpenID Connect Identity Provider service, compatible with CS3 APIs, based on OCIS IDP implementation. This service is required to enable users to log in to 3rdparty services using their ScienceMesh accounts (https://github.com/sciencemesh/sciencemesh/issues/176).

### Contributing a Chart / update to an existing Chart

- [x] Run `helm lint` on the chart dir.
- [x] (Update) Bump the `Chart.yaml` version before merging, to release it as a new version.
- [x] (Update) If the PR includes new configurable parameters in the chart's `values.yaml`. Add documentation in the appropiate [README](idp/README.md).
