### PR TITLE
revad: bump version to 1.21.0 and update maintainers

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,4 +2,7 @@
 
 - [ ] Run `helm lint` on the chart dir.
 - [ ] (Update) Bump the `Chart.yaml` version before merging, to release it as a new version.
+- [ ] (Update) Replace the `annotations` on the `Chart.yaml` with:
+  - `artifacthub.io/changes` - the changes introduced on the PR [with the appropiate format](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations).
+  - `artifacthub.io/images` - the updated tag on the `cs3org/revad` image.
 - [ ] (Update) If the PR includes new configurable parameters in the chart's `values.yaml`. Add documentation in the appropiate README.

--- a/revad/Chart.yaml
+++ b/revad/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: revad
 description: The Reva daemon (revad) helm chart
 type: application
-version: 1.4.2
-appVersion: v1.18.0
+version: 1.5.0
+appVersion: v1.21.0
 kubeVersion: '>= 1.19.0'
 icon: https://reva.link/logo.svg
 home: https://reva.link
@@ -14,8 +14,8 @@ maintainers:
     email: samuel.alfageme.sainz@cern.ch
   - name: labkode
     email: hugo.gonzalez.labrador@cern.ch
-  - name: ishank011
-    email: ishank.arora@cern.ch
+  - name: gmgigi96
+    email: Gianmaria.Del.Monte@cern.ch
 keywords:
   - iop
   - cs3apis
@@ -23,7 +23,7 @@ keywords:
   - sync-and-share
 annotations:
   artifacthub.io/changes: |
-    - "Add imagePullSecrets to deployment"
+    - "Bump revad version to contain [reva#3524](https://github.com/cs3org/reva/pull/3524)"
   artifacthub.io/images: |
     - name: revad
-      image: cs3org/revad:v1.18.0
+      image: cs3org/revad:v1.21.0

--- a/revad/Chart.yaml
+++ b/revad/Chart.yaml
@@ -23,7 +23,11 @@ keywords:
   - sync-and-share
 annotations:
   artifacthub.io/changes: |
-    - "Bump revad version to contain [reva#3524](https://github.com/cs3org/reva/pull/3524)"
+    - kind: changed
+      description: Bump revad version to v.1.21.0
+      links:
+        - name: cs3org/reva#3524
+          url: https://github.com/cs3org/reva/pull/3524
   artifacthub.io/images: |
     - name: revad
       image: cs3org/revad:v1.21.0

--- a/revad/values.yaml
+++ b/revad/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: cs3org/revad
-  tag: v1.18.0
+  tag: v1.21.0
   pullPolicy: Always
   pullSecrets:
     []


### PR DESCRIPTION
cc/ @gmgigi96 requires https://github.com/cs3org/reva/pull/3524 to be merged and tagged as `v1.21.0`

### Contributing a Chart / update to an existing Chart

- [x] Run `helm lint` on the chart dir.
- [x] (Update) Bump the `Chart.yaml` version before merging, to release it as a new version.
- [ ] ~(Update) If the PR includes new configurable parameters in the chart's `values.yaml`. Add documentation in the appropiate README.~
