### PR TITLE
Generate reva configuration from Helm Values

### DIFF
--- a/revad/files/revad.toml.tpl
+++ b/revad/files/revad.toml.tpl
@@ -1,0 +1,12 @@
+{{- /* vim: set filetype=mustache: */ -}}
+{{- with .Values -}}
+{{- $gatewaySvcHost := "0.0.0.0" -}}
+{{- $grpcPort := .service.grpc.port -}}
+
+{{- /* Computed defaults for shared section */ -}}
+{{- $sharedDefaults := dict "gatewaysvc" (printf "%s:%d" $gatewaySvcHost ($grpcPort | int)) -}}
+{{- $sharedOptions := merge .config.shared $sharedDefaults -}}
+
+{{- toToml .config -}}
+
+{{- end -}}

--- a/revad/templates/configmap.yaml
+++ b/revad/templates/configmap.yaml
@@ -8,6 +8,6 @@ metadata:
 data:
 {{- range $filename, $fileContents := .Values.configFiles }}
   {{ $filename }}: |-
-{{ $fileContents | indent 4 }}
+{{ tpl $fileContents $ | indent 4 }}
 {{- end }}
 {{- end }}

--- a/revad/values.yaml
+++ b/revad/values.yaml
@@ -4,8 +4,7 @@ image:
   repository: cs3org/revad
   tag: v1.21.0
   pullPolicy: Always
-  pullSecrets:
-    []
+  pullSecrets: []
 
 service:
   type: ClusterIP
@@ -73,6 +72,38 @@ envFrom:
   # - secretRef:
   #     name: reva-secrets
 
+## Main Reva configuration compiled into revad.toml file
+config:
+  shared:
+    jwt_secret: CHANGE-ME!!!
+  grpc:
+    services:
+      appprovider: {}
+      appregistry: {}
+      authregistry: {}
+      gateway: {}
+      ocmcore: {}
+      ocminvitemanager: {}
+      ocmproviderauthorizer: {}
+      ocmshareprovider: {}
+      preferences: {}
+      publicshareprovider: {}
+      storageregistry: {}
+      userprovider: {}
+      usershareprovider: {}
+  http:
+    services:
+      datagateway: {}
+      dataprovider: {}
+      prometheus: {}
+      ocmd: {}
+      ocdav: {}
+      ocs: {}
+      providerauthorizer: {}
+    middlewares:
+      - providerauthorizer
+      - cors
+
 ingress:
   enabled: false
   services:
@@ -105,27 +136,8 @@ ingress:
 
 # https://reva.link/docs/config/
 configFiles:
-  revad.toml: |
-    [grpc.services.gateway]
-    [grpc.services.storageregistry]
-    [grpc.services.storageprovider]
-    [grpc.services.authprovider]
-    [grpc.services.authregistry]
-    [grpc.services.userprovider]
-    [grpc.services.groupprovider]
-    [grpc.services.usershareprovider]
-    [grpc.services.publicshareprovider]
-    [grpc.services.ocmcore]
-    [grpc.services.ocmshareprovider]
-    [grpc.services.ocminvitemanager]
-    [grpc.services.ocmproviderauthorizer]
-
-    [http.services.datagateway]
-    [http.services.dataprovider]
-    [http.services.prometheus]
-    [http.services.ocmd]
-    [http.services.ocdav]
-    [http.services.ocs]
+  revad.toml: |-
+    {{ tpl (.Files.Get "files/revad.toml.tpl") $ }}
 
   users.json: |
     [


### PR DESCRIPTION
This PR allows chart users to modify individual settings of Reva daemon directly either
by Helm `values.yaml` or by `helm upgrade ... --set config.some-reva-setting=value` method, rather
than by rewriting the whole `revad.toml` file. It also allows for inheritance of common Reva settings,
leveraging built-in Helm values inheritance.

### Contributing a Chart / update to an existing Chart

- [x] Run `helm lint` on the chart dir.
- [ ] (Update) Bump the `Chart.yaml` version before merging, to release it as a new version.
- [ ] (Update) Replace the `annotations` on the `Chart.yaml` with:
  - `artifacthub.io/changes` - the changes introduced on the PR [with the appropiate format](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations).
  - `artifacthub.io/images` - the updated tag on the `cs3org/revad` image.
- [ ] (Update) If the PR includes new configurable parameters in the chart's `values.yaml`. Add documentation in the appropiate README.
