### PR TITLE
Fixed kubeVersion comparision

### DIFF
--- a/revad/Chart.yaml
+++ b/revad/Chart.yaml
@@ -4,7 +4,7 @@ description: The Reva daemon (revad) helm chart
 type: application
 version: 1.5.0
 appVersion: v1.21.0
-kubeVersion: '>= 1.19.0'
+kubeVersion: '>= 1.19.0-0'
 icon: https://reva.link/logo.svg
 home: https://reva.link
 sources:

--- a/wopiserver/Chart.yaml
+++ b/wopiserver/Chart.yaml
@@ -4,7 +4,7 @@ description: A Vendor-neutral Web-application Open Platform Interface (WOPI) gat
 type: application
 version: 0.8.0
 appVersion: v9.4.2
-kubeVersion: '>= 1.19.0'
+kubeVersion: '>= 1.19.0-0'
 home: https://github.com/cs3org/wopiserver
 sources:
   - https://github.com/cs3org/wopiserver


### PR DESCRIPTION
###

This PR changes the `kubeVersion` so that Kubernetes versions with suffixes (like `v1.23.4-r0-CCE22.5.1`)  are properly detected. Otherwise you will receive and error message like

```bash
Error: INSTALLATION FAILED: chart requires kubeVersion: >= 1.19.0 which is incompatible with Kubernetes v1.23.4-r0-CCE22.5.1
```

### Contributing a Chart / update to an existing Chart

- [x] Run `helm lint` on the chart dir.
- [ ] (Update) Bump the `Chart.yaml` version before merging, to release it as a new version.
- [ ] (Update) Replace the `annotations` on the `Chart.yaml` with:
  - `artifacthub.io/changes` - the changes introduced on the PR [with the appropiate format](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations).
  - `artifacthub.io/images` - the updated tag on the `cs3org/revad` image.
- [ ] (Update) If the PR includes new configurable parameters in the chart's `values.yaml`. Add documentation in the appropiate README.
